### PR TITLE
Put SLURM version in RPM release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+VERSION = $(shell git describe --tags --abbrev=0 | sed -r 's/^v//g')
+PKGDIR = $(shell pwd)/pkg
+package:
+	mkdir -p $(PKGDIR)
+	git ls-files | tar -c --transform 's,^,slurm-spank-lua-$(VERSION)/,' -T - | gzip > $(PKGDIR)/slurm-spank-lua-$(VERSION).tar.gz

--- a/slurm-spank-lua.spec
+++ b/slurm-spank-lua.spec
@@ -1,7 +1,9 @@
+%global slurm_version  %(rpm -q slurm-devel --qf "%{VERSION}" 2>/dev/null)
+
 Summary: Slurm Lua SPANK plugin
 Name: slurm-spank-lua
 Version: 0.39
-Release: 1
+Release: %{slurm_version}.1
 License: GPL
 Group: System Environment/Base
 Source0: %{name}-%{version}.tar.gz


### PR DESCRIPTION
Put SLURM version in RPM release
Add make task to build packaged tar ball

Main motivation is to be able to tell from RPM version which version of SLURM the spank Lua RPM was built against and facilitate easier upgrades when the plugin must be rebuilt for newer SLURM installs.