### PR TITLE
Add dist to package release

### DIFF
--- a/slurm-spank-lua.spec
+++ b/slurm-spank-lua.spec
@@ -3,7 +3,7 @@
 Summary: Slurm Lua SPANK plugin
 Name: slurm-spank-lua
 Version: 0.40
-Release: %{slurm_version}.1
+Release: %{slurm_version}.1%{?dist}
 License: GPL
 Group: System Environment/Base
 Source0: %{name}-%{version}.tar.gz


### PR DESCRIPTION
Realized needed dist (ie `el7` or `el8`) in RPM spec as we build RPMs in mock into shared output directory and so need a way to distinguish RHEL7 and RHEL8 builds.

Example file name built against SLURM 20.02.4: `slurm-spank-lua-0.40-20.02.4.1.el7.x86_64.rpm`