### PR TITLE
Force a dependency on versioned libslurm.so

### DIFF
--- a/slurm-spank-lua.spec
+++ b/slurm-spank-lua.spec
@@ -4,7 +4,7 @@
 
 Summary: Slurm Lua SPANK plugin
 Name: slurm-spank-lua
-Version: 0.41
+Version: 0.42
 Release: %{slurm_version}.1%{?dist}
 License: GPL
 Group: System Environment/Base
@@ -71,6 +71,8 @@ rm -rf "$RPM_BUILD_ROOT"
 
 
 %changelog
+* Tue Mar 02 2021 Trey Dockendorf <tdockendorf@osc.edu> - 0.42-1
+- Force a dependency on versioned libslurm.so
 * Tue Aug 11 2020 Trey Dockendorf <tdockendorf@osc.edu> - 0.41-1
 - Keep dist in RPM release
 * Tue Aug 11 2020 Trey Dockendorf <tdockendorf@osc.edu> - 0.40-1

--- a/slurm-spank-lua.spec
+++ b/slurm-spank-lua.spec
@@ -1,4 +1,6 @@
 %global slurm_version  %(rpm -q slurm-devel --qf "%{VERSION}" 2>/dev/null)
+%define _use_internal_dependency_generator 0
+%define __find_requires %{_builddir}/find-requires
 
 Summary: Slurm Lua SPANK plugin
 Name: slurm-spank-lua
@@ -23,11 +25,22 @@ spank(8) manpage).
 
 %prep
 %setup -q
+# Dummy file used to get a RPM dependency on libslurm.so
+echo 'int main(){}' > %{_builddir}/libslurm_dummy.c
+cat <<EOF > %{_builddir}/find-requires
+#!/bin/sh
+# Add dummy to list of files sent to the regular find-requires
+{ echo %{_builddir}/libslurm_dummy; cat; } | \
+    %{_rpmconfigdir}/find-requires
+EOF
+chmod +x %{_builddir}/find-requires
 
 %build
 %{__cc} -g -o lua.o -fPIC -c lua.c
 %{__cc} -g -o lib/list.o -fPIC -c lib/list.c
 %{__cc} -g -shared -fPIC -o lua.so lua.o lib/list.o -llua
+# Dummy file to get a dependency on libslurm
+%{__cc} -lslurm -o %{_builddir}/libslurm_dummy %{_builddir}/libslurm_dummy.c
 
 
 %install


### PR DESCRIPTION
I stole this idea from https://github.com/hpc2n/spank-private-tmp which we also deploy.  It ensures that the application is linked to whatever `libslurm.so.N` that application was built against.  I suppose one alternative to this approach is re-using `slurm_version` variable and just saying something like `Require: slurm = %{slurm_version}` or maybe a bit more complicated logic to extract major & minor version and do something like `Require: slurm >= %{slurm_major_version}.%{slurm_minor_version}.0, slurm < %{slurm_major_version}.%{slurm_minor_version}.99`. I use something like that with Open OnDemand RPMs to enforce supporting major + minor version range.

The main goal with these changes is that when a site does `yum update slurm` it will automatically also install the appropriate slurm-spank-lua RPM that is appropriate for whatever version of SLURM is being upgraded to.  For example we just did upgrade from 20.02.6 to 20.11.4 and had to use `yum update slurm\*` to ensure also pulled in Spank plugin upgrade at same time.