### PR TITLE
Added fix for missing LUA_GLOBALSINDEX in 5.3 lua

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -1045,7 +1045,7 @@ static struct lua_script * lua_script_create (lua_State *L, const char *path)
      *   table.
      */
     lua_pushstring (script->L, "__index");
-    lua_pushvalue (script->L, LUA_GLOBALSINDEX);
+    lua_getglobal (script->L, "_G");
     lua_settable (script->L, -3);
 
     /*  Now set metatable for the new globals table */
@@ -1054,7 +1054,7 @@ static struct lua_script * lua_script_create (lua_State *L, const char *path)
     /*  And finally replace the globals table with the (empty)  table
      *   now at top of the stack
      */
-    lua_replace (script->L, LUA_GLOBALSINDEX);
+    lua_setglobal (script->L, "_G");
 
     return script;
 }

--- a/slurm-spank-lua.spec
+++ b/slurm-spank-lua.spec
@@ -4,7 +4,7 @@
 
 Summary: Slurm Lua SPANK plugin
 Name: slurm-spank-lua
-Version: 0.42
+Version: 0.42.1
 Release: %{slurm_version}.1%{?dist}
 License: GPL
 Group: System Environment/Base


### PR DESCRIPTION
Based on [this commit](https://github.com/flux-framework/flux-core/commit/c635c12db06a17babb271be3d9364d2e11e2a2f0) of flux-core project

LUA_GLOBALSINDEX was removed from lua 5.2, use the globals access functions instead like lua_getglobal, lua_setglobal.