### PR TITLE
Support RHEL8 Lua 5.3

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -1045,7 +1045,11 @@ static struct lua_script * lua_script_create (lua_State *L, const char *path)
      *   table.
      */
     lua_pushstring (script->L, "__index");
+#if LUA_VERSION_NUM >= 502
+    lua_pushglobaltable (script->L);
+#else
     lua_pushvalue (script->L, LUA_GLOBALSINDEX);
+#endif
     lua_settable (script->L, -3);
 
     /*  Now set metatable for the new globals table */
@@ -1054,7 +1058,11 @@ static struct lua_script * lua_script_create (lua_State *L, const char *path)
     /*  And finally replace the globals table with the (empty)  table
      *   now at top of the stack
      */
+#if LUA_VERSION_NUM >= 502
+    lua_pop (script->L, 1);
+#else
     lua_replace (script->L, LUA_GLOBALSINDEX);
+#endif
 
     return script;
 }


### PR DESCRIPTION
I have not tested this, we don't have any HPC systems that are RHEL8, but I am building client systems and our build script builds all SPANK plugins when we build SLURM RPMs so the extent of my testing is that the builds are successful.  I'm not a Lua expert, but some googling lead me to how to replace `LUA_GLOBALSINDEX` for newer Lua.