### PR TITLE
lua 5.2 and higher depricate luaL_register

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -826,7 +826,11 @@ static int lua_spank_table_create (lua_State *L, spank_t sp, int ac, char **av)
     int i;
 
     lua_newtable (L);
+#if LUA_VERSION_NUM >= 502
+    luaL_setfuncs(L, spank_functions, 0);
+#else
     luaL_register (L, NULL, spank_functions);
+#endif
 
     /*  Register spank handle as light userdata inside spank table:
      */


### PR DESCRIPTION
I get an error: when using the spank demo script
```
lua.c: In function _lua_spank_table_create_:
lua.c:829:5: warning: implicit declaration of function _luaL_register_;
did you mean _lua_register_? [-Wimplicit-function-declaration]
     luaL_register (L, NULL, spank_functions);
          ^~~~~~~~~~~~~
               lua_register
```