### PR TITLE
spank get item val uses wrong C type

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -214,7 +214,7 @@ static int name_to_item (const char *name)
 static int l_spank_get_item_val (lua_State *L, spank_t sp, spank_item_t item)
 {
     spank_err_t err;
-    long val;
+    int val;
 
     err = spank_get_item (sp, item, &val);
     if (err != ESPANK_SUCCESS)


### PR DESCRIPTION
lua cconnvert C-long to  LUA-number differntly
Added C debug  option to display value in C
```
[2021-09-06T13:53:22.384] debug:  spank/lua: l_spank_get_item_val: 31000
[2021-09-06T13:53:22.384] value S_JOB_UID=94755568515352
[2021-09-06T13:53:22.384] debug:  spank/lua: l_spank_get_item_val: 31010
[2021-09-06T13:53:22.384] value S_JOB_GID=94755568515362
```

when switched to int:
```
[2021-09-06T13:55:29.750] debug:  spank/lua: l_spank_get_item_val: 31000
[2021-09-06T13:55:29.750] value S_JOB_UID=31000
[2021-09-06T13:55:29.750] debug:  spank/lua: l_spank_get_item_val: 31010
[2021-09-06T13:55:29.750] value S_JOB_GID=31010
```