### PR TITLE
lua: use a new state for each script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+run_scripts
+lua.so

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,11 @@ PKGDIR = $(shell pwd)/pkg
 package:
 	mkdir -p $(PKGDIR)
 	git ls-files | tar -c --transform 's,^,slurm-spank-lua-$(VERSION)/,' -T - | gzip > $(PKGDIR)/slurm-spank-lua-$(VERSION).tar.gz
+
+CFLAGS = -fPIC -g
+clean:
+	rm -f lua.o run_scripts.o lib/list.o lua.so run_scripts
+lua.so: lua.o lib/list.o
+	cc -shared -fPIC -o $@ $^ -llua
+run_scripts: run_scripts.o lua.o lib/list.o
+	cc $^ -o $@ -llua -ldl

--- a/lua.c
+++ b/lua.c
@@ -1267,8 +1267,12 @@ int spank_lua_init (spank_t sp, int ac, char *av[])
     void *lua_handle = NULL;
 
     char *const lua_libs[] = {
-        "liblua.so",
-#if LUA_VERSION_NUM == 503
+#if LUA_VERSION_NUM == 504
+        "liblua-5.4.so",
+        "liblua5.4.so",
+        "liblua5.4.so.0",
+        "liblua.so.5.4",
+#elif LUA_VERSION_NUM == 503
         "liblua-5.3.so",
         "liblua5.3.so",
         "liblua5.3.so.0",
@@ -1284,6 +1288,7 @@ int spank_lua_init (spank_t sp, int ac, char *av[])
         "liblua5.1.so.0",
         "liblua.so.5.1",
 #endif
+        "liblua.so",
         NULL
     };
 

--- a/run_scripts.c
+++ b/run_scripts.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+#include <stdarg.h>
+
+
+/* slurm_* prints to stdout */
+void slurm_debug(const char *fmt, ...) {
+  va_list arg;
+
+  printf("debug: ");
+  va_start (arg, fmt);
+  vprintf (fmt, arg);
+  va_end (arg);
+  printf("\n");
+}
+void slurm_error(const char *fmt, ...) {
+  va_list arg;
+
+  printf("error: ");
+  va_start (arg, fmt);
+  vprintf (fmt, arg);
+  va_end (arg);
+  printf("\n");
+}
+void slurm_info(const char *fmt, ...) {
+  va_list arg;
+
+  printf("info: ");
+  va_start (arg, fmt);
+  vprintf (fmt, arg);
+  va_end (arg);
+  printf("\n");
+}
+void slurm_verbose(const char *fmt, ...) {
+  va_list arg;
+
+  printf("verbose: ");
+  va_start (arg, fmt);
+  vprintf (fmt, arg);
+  va_end (arg);
+  printf("\n");
+}
+
+#include <slurm/spank.h>
+
+/* empty stubs to make linker happy */
+enum spank_context spank_context(void) {
+	return S_CTX_SLURMD;
+}
+spank_err_t spank_getenv(spank_t spank, const char *var, char *buf, int len) {
+	return ESPANK_ERROR;
+}
+spank_err_t spank_get_item(spank_t spank, spank_item_t item, ...) {
+	return ESPANK_ERROR;
+}
+spank_err_t spank_option_register(spank_t spank, struct spank_option *opt) {
+	return ESPANK_ERROR;
+}
+int spank_remote(spank_t spank) {
+	return ESPANK_ERROR;
+}
+spank_err_t spank_setenv(spank_t spank, const char *var, const char *val, int overwrite) {
+	return ESPANK_ERROR;
+}
+const char * spank_strerror(spank_err_t err) {
+	return "spankerr";
+}
+spank_err_t spank_unsetenv(spank_t spank, const char *var) {
+	return ESPANK_ERROR;
+}
+
+
+
+/* function we're testing with */
+int slurm_spank_init(spank_t sp, int ac, char *av[]);
+
+int main(int argc, char *argv[]) {
+	spank_t sp = {0};
+	int rc;
+	argc--; argv++;
+	rc = slurm_spank_init(sp, argc, argv);
+	printf("init: %d\n", rc);
+
+	return rc;
+}
+
+
+


### PR DESCRIPTION
three unrelated things

- lua: use a new state for each script (Fixes: #14)
```
lua >= 5.2 way of giving each thread their own global stack obviously
did not work properly.
Give up and create a new full lua state for each script, the whole
lua VM is not that big and is cleaned up immediately anyway.
```


- tests: add test wrapper for the lib
```
add a wrapper to run lua scripts's slurm_spank_init function for tests
usage:
  make run_scripts
  ./run_scripts 'scripts/*.lua'

(note the glob is done by lua.c and should not be left to shell)
```

happy to drop this one ^ I just didn't want to run slurm

- lua_libs: try version-specific lib first (and add lua5.4)
```
when multiple versions of the lib are installed, try harder to
use the lib we were compiled with.
The versionless liblua.so should only be used as fallback
```