### PR TITLE
Use pkg-config to find lua headers

### DIFF
--- a/slurm-spank-lua.spec
+++ b/slurm-spank-lua.spec
@@ -11,9 +11,9 @@ Group: System Environment/Base
 Source0: %{name}-%{version}.tar.gz
 BuildRoot:  %{_tmppath}/%{name}-%{version}
 
-BuildRequires: slurm-devel bison flex
-BuildRequires: lua-devel >= 5.1
-Requires:      slurm lua-devel >= 5.1
+BuildRequires: slurm-devel bison flex pkgconfig(pkg-config)
+BuildRequires: pkgconfig(lua) >= 5.1
+Requires:      slurm
 
 %description
 The lua.so spank plugin for Slurm allows lua scripts to take the place of
@@ -36,7 +36,7 @@ EOF
 chmod +x %{_builddir}/find-requires
 
 %build
-%{__cc} -g -o lua.o -fPIC -c lua.c
+%{__cc} -g -o lua.o -fPIC -c lua.c $(pkg-config --cflags lua)
 %{__cc} -g -o lib/list.o -fPIC -c lib/list.c
 %{__cc} -g -shared -fPIC -o lua.so lua.o lib/list.o -llua
 # Dummy file to get a dependency on libslurm


### PR DESCRIPTION
rpm fails to build on SLES-15-sp3 because the lua headers are in `/usr/include/lua5.3`.  Use `pkg-config` to find them (note Slurm already `BuildRequires: pkg-config` so this should not be a new dependency).

I removed `lua-devel` from the explicit `Requires` because the automatic dependency system should identify the proper package that contains the lua shared library (although it appears to be `lua-devel` on both RHEL7 and SLES15). I can re-spin this patch without that change if you prefer to leave it as-is.