### PR TITLE
Always build with support for spank:getopt()

### DIFF
--- a/lua.c
+++ b/lua.c
@@ -742,7 +742,6 @@ static int l_spank_option_register (lua_State *L)
     return (rc);
 }
 
-#if HAVE_SPANK_OPTION_GETOPT
 static int l_spank_option_getopt (lua_State *L)
 {
     spank_t sp;
@@ -782,7 +781,6 @@ static int l_spank_option_getopt (lua_State *L)
 
     return (1);
 }
-#endif /* if HAVE_SPANK_OPTION_GETOPT */
 
 static int l_spank_remote (lua_State *L)
 {
@@ -846,9 +844,7 @@ static const struct luaL_Reg spank_functions [] = {
     { "remote",               l_spank_remote },
     { "register_option",      l_spank_option_register },
     { "get_item",             l_spank_get_item },
-#if HAVE_SPANK_OPTION_GETOPT
     { "getopt",               l_spank_option_getopt },
-#endif
     { "getenv",               l_spank_getenv },
     { "setenv",               l_spank_setenv },
     { "unsetenv",             l_spank_unsetenv },


### PR DESCRIPTION
From what I can tell, this conditional has been here for 12 years from when the getopt function was new. It has been upstream that long, and no supported Slurm would be without it